### PR TITLE
test: add unit tests for enterRaffle()  feat: add getter tests for Raffle  

### DIFF
--- a/src/Raffle.sol
+++ b/src/Raffle.sol
@@ -39,7 +39,11 @@ contract Raffle is VRFConsumerBaseV2Plus {
     error Raffle__TransferFailed();
     error Raffle__RaffleNotOpen();
     error Raffle__RaffleIsFull();
-    error Raffle__upkeepNotNeeded(uint256 balance, uint256 playersLength, uint256 raffleState);
+    error Raffle__upkeepNotNeeded(
+        uint256 balance,
+        uint256 playersLength,
+        uint256 raffleState
+    );
 
     /*Type Declarations */
     enum RaffleState {
@@ -116,33 +120,49 @@ contract Raffle is VRFConsumerBaseV2Plus {
      * @return upkeepNeeded - true if it's time to restart the lottery.
      * @return - ignored
      */
-    function checkUpkeep(bytes memory) public view returns (bool upkeepNeeded, bytes memory) {
+    function checkUpkeep(
+        bytes memory
+    ) public view returns (bool upkeepNeeded, bytes memory) {
         bool isOpen = s_raffleState == RaffleState.OPEN;
         bool hasBalance = address(this).balance > 0;
         bool hasPlayers = s_players.length > 0;
         bool requiredAmountOfPlayers = s_players.length == s_maxAmountOfPlayers;
-        upkeepNeeded = isOpen && hasBalance && hasPlayers && requiredAmountOfPlayers;
+        upkeepNeeded =
+            isOpen &&
+            hasBalance &&
+            hasPlayers &&
+            requiredAmountOfPlayers;
         return (upkeepNeeded, "");
     }
 
     function performUpkeep(bytes calldata) external {
-        (bool upkeepNeeded,) = checkUpkeep("");
+        (bool upkeepNeeded, ) = checkUpkeep("");
         if (!upkeepNeeded) {
-            revert Raffle__upkeepNotNeeded(address(this).balance, s_players.length, uint256(s_raffleState));
+            revert Raffle__upkeepNotNeeded(
+                address(this).balance,
+                s_players.length,
+                uint256(s_raffleState)
+            );
         }
         s_raffleState = RaffleState.CALCULATING;
-        VRFV2PlusClient.RandomWordsRequest memory request = VRFV2PlusClient.RandomWordsRequest({
-            keyHash: i_keyHash,
-            subId: i_subscriptionId,
-            requestConfirmations: REQUEST_CONFIRMATIONS,
-            callbackGasLimit: i_callbackGasLimit,
-            numWords: NUM_WORDS,
-            extraArgs: VRFV2PlusClient._argsToBytes(VRFV2PlusClient.ExtraArgsV1({nativePayment: false}))
-        });
+        VRFV2PlusClient.RandomWordsRequest memory request = VRFV2PlusClient
+            .RandomWordsRequest({
+                keyHash: i_keyHash,
+                subId: i_subscriptionId,
+                requestConfirmations: REQUEST_CONFIRMATIONS,
+                callbackGasLimit: i_callbackGasLimit,
+                numWords: NUM_WORDS,
+                extraArgs: VRFV2PlusClient._argsToBytes(
+                    VRFV2PlusClient.ExtraArgsV1({nativePayment: false})
+                )
+            });
         uint256 requestId = s_vrfCoordinator.requestRandomWords(request);
     }
 
-    function fulfillRandomWords(uint256 requestId, uint256[] calldata randomWords) internal override {
+    function fulfillRandomWords(
+        uint256 requestId,
+        uint256[] calldata randomWords
+    ) internal override {
         uint256 indexOfWinner = randomWords[0] % s_players.length;
         address payable recentWinner = s_players[indexOfWinner];
         s_recentWinner = recentWinner;
@@ -151,7 +171,7 @@ contract Raffle is VRFConsumerBaseV2Plus {
         s_players = new address payable[](0);
         s_lastTimeStamp = block.timestamp;
 
-        (bool success,) = recentWinner.call{value: address(this).balance}("");
+        (bool success, ) = recentWinner.call{value: address(this).balance}("");
         if (!success) {
             revert Raffle__TransferFailed();
         }
@@ -172,5 +192,9 @@ contract Raffle is VRFConsumerBaseV2Plus {
 
     function getPlayersCount() public view returns (uint256) {
         return s_players.length;
+    }
+
+    function getRaffleState() public view returns (RaffleState) {
+        return s_raffleState;
     }
 }

--- a/src/RaffleFactory.sol
+++ b/src/RaffleFactory.sol
@@ -8,7 +8,11 @@ contract RaffleFactory {
 
     address[] public deployedRaffles;
 
-    event RaffleCreated(address raffleAddress, uint8 poolType, uint256 entranceFee);
+    event RaffleCreated(
+        address raffleAddress,
+        uint8 poolType,
+        uint256 entranceFee
+    );
 
     function createPool(
         uint8 poolType,
@@ -25,8 +29,15 @@ contract RaffleFactory {
         }
 
         // Deploy new raffle
-        Raffle raffle =
-            new Raffle(entranceFee, interval, vrfCoordinator, gasLane, subscriptionId, callbackGasLimit, poolType);
+        Raffle raffle = new Raffle(
+            entranceFee,
+            interval,
+            vrfCoordinator,
+            gasLane,
+            subscriptionId,
+            callbackGasLimit,
+            poolType
+        );
 
         deployedRaffles.push(address(raffle));
         emit RaffleCreated(address(raffle), poolType, entranceFee);


### PR DESCRIPTION
- Added initial test file for Raffle contract
- Covered revert cases in enterRaffle (not enough ETH, not open, raffle full)
- Added test for getters
- Set up VRF mock and subscription in test setup because we haven't implemented the deployment Scripts yet